### PR TITLE
fix: profile meta title

### DIFF
--- a/src/pages/Profile/Comments.vue
+++ b/src/pages/Profile/Comments.vue
@@ -1,10 +1,4 @@
-<script setup lang="ts">
-import { useMeta } from 'vue-meta';
-useMeta({
-	title: `authorName - Blogchain`,
-	htmlAttrs: { lang: 'en', amp: true },
-});
-</script>
+<script setup lang="ts"></script>
 
 <template>
 	<div id="scrollable_content">{{ $route.params }}/comments</div>

--- a/src/pages/Profile/Index.vue
+++ b/src/pages/Profile/Index.vue
@@ -17,11 +17,6 @@ import { getUserInfoNEAR } from '@/backend/near';
 import { handleError } from '@/plugins/toast';
 import BioPopup from '@/components/popups/BioPopup.vue';
 
-useMeta({
-	title: `authorName - Blogchain`,
-	htmlAttrs: { lang: 'en', amp: true },
-});
-
 const store = useStore();
 const router = useRouter();
 const route = useRoute();
@@ -34,6 +29,11 @@ const authorID = route.params.id;
 const profileExists = ref<boolean>(false);
 
 const profile = computed(() => profilesStore.getProfile(authorID));
+
+useMeta({
+	title: profile.value.name ? `${profile.value.name as string} -  Blogchain` : `${authorID as string} -  Blogchain`,
+	htmlAttrs: { lang: 'en', amp: true },
+});
 
 onMounted(async () => {
 	try {

--- a/src/pages/Profile/Index.vue
+++ b/src/pages/Profile/Index.vue
@@ -31,7 +31,7 @@ const profileExists = ref<boolean>(false);
 const profile = computed(() => profilesStore.getProfile(authorID));
 
 useMeta({
-	title: profile.value.name ? `${profile.value.name as string} -  Blogchain` : `${authorID as string} -  Blogchain`,
+	title: profile.value.name ? `${profile.value.name as string} -  Blogchain` : `@${authorID as string} -  Blogchain`,
 	htmlAttrs: { lang: 'en', amp: true },
 });
 

--- a/src/pages/Profile/Posts.vue
+++ b/src/pages/Profile/Posts.vue
@@ -1,10 +1,4 @@
-<script setup lang="ts">
-import { useMeta } from 'vue-meta';
-useMeta({
-	title: `authorName - Blogchain`,
-	htmlAttrs: { lang: 'en', amp: true },
-});
-</script>
+<script setup lang="ts"></script>
 
 <template>
 	<div id="scrollable_content">{{ $route.params }}/posts</div>

--- a/src/pages/Profile/Reposts.vue
+++ b/src/pages/Profile/Reposts.vue
@@ -1,10 +1,4 @@
-<script setup lang="ts">
-import { useMeta } from 'vue-meta';
-useMeta({
-	title: `authorName - Blogchain`,
-	htmlAttrs: { lang: 'en', amp: true },
-});
-</script>
+<script setup lang="ts"></script>
 
 <template>
 	<div id="scrollable_content">{{ $route.params }}/reposts</div>


### PR DESCRIPTION
Set the default meta title on profile. Removed the `meta-title` on `comments` and `re-posts` since they are nested child component of the main profile page. Also they share the same `meta-title` and considered setting a main title on the index profile page.