### PR TITLE
fix: subscription

### DIFF
--- a/src/components/popups/SubscriptionsPopup.vue
+++ b/src/components/popups/SubscriptionsPopup.vue
@@ -69,13 +69,12 @@ const emit = defineEmits([`close`]);
 function startReading() {
 	emit(`close`);
 	useSubscription.fetchSubs(store.$state.id);
-	if (route.name === `post-post`) {
-		location.reload();
-	}
-	if (route.name === `id-id`) {
+	if (route.name === `Post Reader`) {
+		window.location.reload();
+	} else if (route.name === `Profile` || `Posts` || `Comments` || `Reposts`) {
 		toastSuccess(`Subscribed! Reloading profile...`);
 		setTimeout(() => {
-			location.reload();
+			window.location.reload();
 		}, 4000);
 	}
 }
@@ -564,7 +563,7 @@ onMounted(() => {
 						:user-is-followed="userIsFollowed ? userIsFollowed : false"
 						:toggle-friend="toggleFriend"
 						:selected-tier="selectedTier"
-						@star-reading="startReading"
+						@start-reading="startReading"
 					/>
 				</article>
 				<!-- Step 5: Payment policy page -->

--- a/src/components/popups/SubscriptionsPopup.vue
+++ b/src/components/popups/SubscriptionsPopup.vue
@@ -71,7 +71,9 @@ function startReading() {
 	useSubscription.fetchSubs(store.$state.id);
 	if (route.name === `Post Reader`) {
 		window.location.reload();
-	} else if (route.name === `Profile` || `Posts` || `Comments` || `Reposts`) {
+	}
+
+	if (route.name === `Profile` || `Posts` || `Comments` || `Reposts`) {
 		toastSuccess(`Subscribed! Reloading profile...`);
 		setTimeout(() => {
 			window.location.reload();

--- a/src/components/subscriptions/SubConfirmation.vue
+++ b/src/components/subscriptions/SubConfirmation.vue
@@ -3,7 +3,7 @@ import FriendButton from '@/components/FriendButton.vue';
 import Avatar from '@/components/Avatar.vue';
 import CrownIcon from '@/components/icons/CrownIcon.vue';
 import { Profile } from '@/backend/profile';
-import { darkMode } from '@/plugins/colors';
+import { useStoreSettings } from '@/store/settings';
 import { SubscriptionTier } from '@/store/paymentProfile';
 import { useConnectionsStore } from '@/store/connections';
 import { useStore } from '@/store/session';
@@ -14,6 +14,7 @@ const props = withDefaults(
 	{},
 );
 
+const storeSetting = useStoreSettings();
 const userIsFollowed = computed(() => useConnectionsStore().getFollowStatus(useStore().$state.id, props.author.id));
 
 defineEmits([`startReading`]);
@@ -27,7 +28,7 @@ defineEmits([`startReading`]);
 			<p class="text-base text-center text-gray5 dark:text-gray3 mb-4">You are now subscribed to:</p>
 		</div>
 		<!-- Premium profile preview -->
-		<div class="flex flex-row items-center p-4 border border-neutral rounded-lg w-2/3">
+		<div class="flex flex-row items-center p-4 border border-neutral rounded-lg w-2/3 mx-auto">
 			<Avatar
 				class="flex-shrink-0"
 				:authorid="props.author.id"
@@ -54,7 +55,9 @@ defineEmits([`startReading`]);
 		</div>
 		<div class="w-full flex flex-col justify-center items-center text-center px-10 mt-5">
 			<p class="text-base text-center text-gray5 dark:text-gray3 mb-4 max-w-md">
-				All premium articles under {{ props.selectedTier ? props.selectedTier.name : `` }} tier<br />
+				All premium articles under
+				<span class="font-semibold text-lg text-primary">{{ props.selectedTier ? props.selectedTier.name : `` }}</span>
+				tier<br />
 				are now unlocked for your account.
 			</p>
 			<button
@@ -74,7 +77,11 @@ defineEmits([`startReading`]);
 		</div>
 		<img
 			loading="lazy"
-			:src="darkMode ? `@/assets/brand/dark/subscriptions.webp` : `@/assets/brand/light/subscriptions.webp`"
+			:src="
+				storeSetting.$state.darkMode
+					? require(`@/assets/images/brand/dark/subscriptions.webp`)
+					: require(`@/assets/images/brand/light/subscriptions.webp`)
+			"
 			class="h-auto rounded-lg"
 		/>
 	</div>

--- a/src/store/subscriptions.ts
+++ b/src/store/subscriptions.ts
@@ -72,17 +72,16 @@ export const useSubscriptionStore = defineStore(`subscriptions`, {
 				}
 
 				subsWithProfiles.forEach((subWithProfile) => {
-					// needs refactor
 					if (!subWithProfile.isActive) {
-						const checkInactive = this.$state.inActive.findIndex((inSub) => inSub.authorID === subWithProfile.authorID);
+						const checkInactive = this.inActive.findIndex((inSub) => inSub.authorID === subWithProfile.authorID);
 						if (checkInactive === -1) {
-							this.$state.inActive.push(subWithProfile);
+							this.inActive.push(subWithProfile);
 						}
-					} else {
-						const checkActive = this.$state.active.findIndex((aSub) => aSub.authorID === subWithProfile.authorID);
-						if (checkActive === -1) {
-							this.$state.active.push(subWithProfile);
-						}
+						return;
+					}
+					const checkActive = this.active.findIndex((aSub) => aSub.authorID === subWithProfile.authorID);
+					if (checkActive === -1) {
+						this.$state.active.push(subWithProfile);
 					}
 				});
 			} catch (err) {

--- a/src/store/subscriptions.ts
+++ b/src/store/subscriptions.ts
@@ -72,11 +72,18 @@ export const useSubscriptionStore = defineStore(`subscriptions`, {
 				}
 
 				subsWithProfiles.forEach((subWithProfile) => {
-					if (subWithProfile.isActive) {
-						this.$state.active.push(subWithProfile);
-						return;
+					// needs refactor
+					if (!subWithProfile.isActive) {
+						const checkInactive = this.$state.inActive.findIndex((inSub) => inSub.authorID === subWithProfile.authorID);
+						if (checkInactive === -1) {
+							this.$state.inActive.push(subWithProfile);
+						}
+					} else {
+						const checkActive = this.$state.active.findIndex((aSub) => aSub.authorID === subWithProfile.authorID);
+						if (checkActive === -1) {
+							this.$state.active.push(subWithProfile);
+						}
 					}
-					this.$state.inActive.push(subWithProfile);
 				});
 			} catch (err) {
 				handleError(`Error when fetching subscriptions`);


### PR DESCRIPTION
- [x] Fix: Prevent duplicated subs when the mounted hook is called twice.
 - [x] Fix: when the user is on the nested routes (`posts`, `reposts`, `comment`) section, page reload is not initiated after successful subscription due to `route` name changes. Fix to ensure the cases where the user might be on any nested route